### PR TITLE
Update to clojure 1.10.1 and core.logic 0.8.11

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,10 +1,10 @@
 (defproject archimedes "1.0.0-SNAPSHOT"
   :description "FIXME: write"
-  :dependencies [[org.clojure/clojure "1.5.1"]
-                 [org.clojure/core.logic "0.7.5"]]
+  :dependencies [[org.clojure/clojure "1.10.1"]
+                 [org.clojure/core.logic "0.8.11"]]
   :java-source-paths ["java"]
   ;; TODO: lein issue
   :aliases {"build" ["do"
                      "update-in" ":prep-tasks" "empty" "--"
-                     "run" "-m" "Archimedes.bar/code-gen" "java/archimedes/MathOps.java" "MathOps,"
+                     "run" "-m" "Archimedes.bar/code-gen" "java/archimedes/MathOps.java" "MathOps"
                      "javac"]})

--- a/src/Archimedes/bar.clj
+++ b/src/Archimedes/bar.clj
@@ -1,7 +1,9 @@
 (ns Archimedes.bar
   (:refer-clojure :exclude [== gensym])
   (:require [clojure.core.logic :refer :all]
-            [Archimedes.db :refer [types- type-db operations operations- natural-division-result]]
+            [clojure.core.logic.pldb :as pldb]
+            [Archimedes.db :refer [types- type-db operations operations- natural-division-result
+                                   types-ldb operations-ldb]]
             [Archimedes.codegen :refer [h]]
             [clojure.java.io :as io]
             [Archimedes.predicates :refer :all]))
@@ -104,21 +106,21 @@
 ;; driver
 
 (defn f []
-  (run* [q]
-    (fresh [op arg1 arg2 return]
-      (setupo q op arg1 arg2 return)
-      (binaryo op)
-      (constrain-returno return)
-      (sameo op arg1 arg2 return)
-      (floating-point-contaminato arg1 arg2 return)
-      (ratio-contaminato arg1 arg2 return)
-      (object-contaminato arg1 arg2 return)
-      (number-contaminato arg1 arg2 return)
-      (bigdecimal-contaminato arg1 arg2 return)
-      (special-diviso op arg1 arg2 return)
-      (fixed-width-cantaminato op arg1 arg2 return)
-      (natural-contaminato op arg1 arg2 return)
-      )))
+  (pldb/with-dbs [operations-ldb types-ldb]
+   (run* [q]
+     (fresh [op arg1 arg2 return]
+       (setupo q op arg1 arg2 return)
+       (binaryo op)
+       (constrain-returno return)
+       (sameo op arg1 arg2 return)
+       (floating-point-contaminato arg1 arg2 return)
+       (ratio-contaminato arg1 arg2 return)
+       (object-contaminato arg1 arg2 return)
+       (number-contaminato arg1 arg2 return)
+       (bigdecimal-contaminato arg1 arg2 return)
+       (special-diviso op arg1 arg2 return)
+       (fixed-width-cantaminato op arg1 arg2 return)
+       (natural-contaminato op arg1 arg2 return)))))
 
 (defn code-gen [output class-name]
   (.mkdirs (.getParentFile (io/file output)))

--- a/src/Archimedes/codegen.clj
+++ b/src/Archimedes/codegen.clj
@@ -1,7 +1,9 @@
 (ns Archimedes.codegen
   (:refer-clojure :exclude [== gensym])
   (:require [clojure.core.logic :refer :all]
-            [Archimedes.db :refer [types- type-db operations operations- natural-division-result]]
+            [clojure.core.logic.pldb :as pldb]
+            [Archimedes.db :refer [types- type-db operations operations- natural-division-result
+                                   types-ldb operations-ldb]]
             [clojure.java.io :as io]
             [Archimedes.predicates :refer :all]))
 
@@ -400,7 +402,7 @@
       (fresh [aa bb]
         (casto arg1 a1 in-code aa)
         (casto arg2 b1 aa bb)
-        (conso (str (ctor :Ratio a1 b1) ";") 
+        (conso (str (ctor :Ratio a1 b1) ";")
                bb
                out-code)))]
    [(== op :divide)
@@ -578,8 +580,9 @@
                                     an2 (gensym 'b)]
                                 [an1 an2
                                  (doall
-                                  (run 1 [q]
-                                    (g op (->V arg1 an1) (->V arg2 an2) return () q)))]))
+                                   (pldb/with-dbs [types-ldb operations-ldb]
+                                    (run 1 [q]
+                                      (g op (->V arg1 an1) (->V arg2 an2) return () q))))]))
               x (reverse x)]]
     (cond
      (seq x)

--- a/src/Archimedes/db.clj
+++ b/src/Archimedes/db.clj
@@ -1,8 +1,10 @@
 (ns Archimedes.db
-  (:refer-clojure :exclude [==])
-  (:require [clojure.core.logic :refer :all]))
+  (:refer-clojure :exclude [== indexed?])
+  (:require [clojure.core.logic :refer :all :as l]
+            [clojure.core.logic.pldb :as pldb]))
 
-(defrel types-
+(pldb/db-rel
+  types-
   ^:indexed
   type-name
   ^:indexed
@@ -18,7 +20,7 @@
   ^:indexed
   return-or-no-return)
 
-(defrel operations-
+(pldb/db-rel operations-
   ^:index op-name
   ^:index arity
   ^:index return)
@@ -128,19 +130,21 @@
    ;; :gte {:arity 2}
    })
 
-(doseq [[type-name data] type-db]
-  (fact types- type-name
-        (:representation data)
-        (:natural-or-other data)
-        (:width data)
-        (:point data)
-        (:boxed-or-unboxed data)
-        (:return-or-no-return data)))
+(def types-ldb
+  (apply pldb/db
+         (for [[type-name data] type-db]
+           [types-
+            type-name
+            (:representation data)
+            (:natural-or-other data)
+            (:width data)
+            (:point data)
+            (:boxed-or-unboxed data)
+            (:return-or-no-return data)])))
 
-(doseq [[op-name data] operations]
-  (fact operations-
-        op-name
-        (:arity data)
-        (:return data)))
+(def operations-ldb
+  (apply pldb/db
+         (for [[op-name data] operations]
+           [operations- op-name (:arity data) (:return data)])))
 
 (def natural-division-result :Ratio)


### PR DESCRIPTION
principal changes are that there's no default database for
`fact`. Easy switch to named databases and then use them in two spots

I verified this still works with javac on java/archidemes/MathOps.java. I can import and use the resulting static class.

One confusion I had was the comma in the lein task. Seems strange and when I ran `code-gen` manually it left a comma in the class definition.